### PR TITLE
Fixing GitHub link

### DIFF
--- a/BetterTouchToolDocs/README.md
+++ b/BetterTouchToolDocs/README.md
@@ -2,6 +2,4 @@
 
 This documentation is always a work in progress and will most likely not cover the most current features of BetterTouchTool.
 
-If you have specific questions please ask on Github [http://github.com/fifafu/BetterTouchTool](github.com/fifafu/BetterTouchTool) or Google for a solution. Most likely other BetterTouchTool users have already solved your issue 🙂
-
-
+If you have specific questions please ask on [GitHub](https://github.com/fifafu/BetterTouchTool) or Google for a solution. Most likely other BetterTouchTool users have already solved your issue 🙂


### PR DESCRIPTION
Fixing incorrect GitHub link from the documentation page, http://docs.bettertouchtool.net/.